### PR TITLE
Add solution for finding the shortest path in a board

### DIFF
--- a/programmers/level-2/038.리코쳇 로봇.js
+++ b/programmers/level-2/038.리코쳇 로봇.js
@@ -1,0 +1,57 @@
+function solution(board) {
+  const n = board.length;
+  const m = board[0].length;
+  const visited = Array(n)
+    .fill()
+    .map(() => Array(m).fill(0));
+  const directions = [
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+  ];
+
+  let start;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < m; j++) {
+      if (board[i][j] === "R") start = [i, j, 0];
+    }
+  }
+
+  visited[start[0]][start[1]] = 1;
+
+  const queue = [start];
+  while (queue.length) {
+    const [currentY, currentX, move] = queue.shift();
+    if (board[currentY][currentX] === "G") {
+      return move;
+    }
+
+    for (const [moveY, moveX] of directions) {
+      let nextY = currentY + moveY;
+      let nextX = currentX + moveX;
+      while (nextY >= 0 && nextY < n && nextX >= 0 && nextX < m) {
+        if (board[nextY][nextX] === "D") {
+          if (!visited[nextY - moveY][nextX - moveX]) {
+            queue.push([nextY - moveY, nextX - moveX, move + 1]);
+            visited[nextY - moveY][nextX - moveX] = 1;
+          }
+          break;
+        }
+        nextY += moveY;
+        nextX += moveX;
+      }
+
+      if (nextY < 0 || nextY >= n || nextX < 0 || nextX >= m) {
+        if (!visited[nextY - moveY][nextX - moveX]) continue;
+        queue.push([nextY - moveY, nextX - moveX, move + 1]);
+        visited[nextY - moveY][nextX - moveX] = 1;
+      }
+    }
+  }
+
+  return -1;
+}
+
+console.log(solution(["...D..R", ".D.G...", "....D.D", "D....D.", "..D...."]));


### PR DESCRIPTION
This pull request introduces a new solution for the "Ricochet Robot" problem in the file `programmers/level-2/038.리코쳇 로봇.js`. The solution implements a breadth-first search (BFS) algorithm to determine the minimum number of moves required for the robot to reach the goal while considering obstacles and boundaries.

### Key Changes:

#### New Functionality:
* Added the `solution` function, which calculates the minimum moves for the robot to reach the goal ('G') from its starting position ('R') on a given board. The function uses BFS to explore possible moves while avoiding obstacles ('D') and staying within the board boundaries.

#### Algorithm Details:
* Introduced a `visited` matrix to track visited positions and prevent redundant processing.
* Defined movement directions (up, down, left, right) and implemented logic to handle the robot's ricochet behavior until it encounters an obstacle or boundary.
* Utilized a queue to manage BFS traversal, storing the current position and move count for each step.

#### Example Usage:
* Added a test case to validate the solution with a sample board configuration, logging the result to the console.