### PR TITLE
Add solutions for two new programming challenges

### DIFF
--- a/programmers/level-3/017-풍선 터트리기.js
+++ b/programmers/level-3/017-풍선 터트리기.js
@@ -1,0 +1,29 @@
+function solution(a) {
+  if (a.length <= 2) {
+    return a.length;
+  }
+
+  let leftMinimum = Infinity;
+  let minimumIndex = 0;
+  let count = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] < leftMinimum) {
+      leftMinimum = a[i];
+      minimumIndex = i;
+      count += 1;
+    }
+  }
+
+  let rightMinimum = Infinity;
+  for (let i = a.length - 1; i > minimumIndex; i--) {
+    if (a[i] < rightMinimum) {
+      rightMinimum = a[i];
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+console.log(solution([-16, 27, 65, -2, 58, -92, -71, -68, -61, -33]));

--- a/programmers/level-3/018-다단계 칫솔 판매.js
+++ b/programmers/level-3/018-다단계 칫솔 판매.js
@@ -1,0 +1,43 @@
+function solution(enroll, referral, seller, amount) {
+  const team = {};
+  const money = {};
+
+  for (let i = 0; i < enroll.length; i++) {
+    money[enroll[i]] = 0;
+
+    if (!team[enroll[i]]) {
+      team[enroll[i]] = [referral[i]];
+      continue;
+    }
+
+    team[enroll[i]].push(referral[i]);
+  }
+
+  function dfs(seller, cost) {
+    if (seller === "-") return;
+
+    const leader = team[seller][0];
+    const leaderCost = Math.floor(cost / 10);
+    const sellerCost = cost - leaderCost;
+
+    money[seller] += sellerCost;
+
+    if (leaderCost < 1) return;
+    dfs(leader, leaderCost);
+  }
+
+  for (let i = 0; i < seller.length; i++) {
+    dfs(seller[i], amount[i] * 100);
+  }
+
+  return Object.values(money);
+}
+
+console.log(
+  solution(
+    ["john", "mary", "edward", "sam", "emily", "jaimie", "tod", "young"],
+    ["-", "-", "mary", "edward", "mary", "mary", "jaimie", "edward"],
+    ["young", "john", "tod", "emily", "mary"],
+    [12, 4, 2, 5, 10]
+  )
+);


### PR DESCRIPTION
This pull request adds implementations for two new algorithmic solutions in JavaScript, each solving a different problem from a programming challenge platform. Below is a summary of the changes:

### New Algorithm Implementations:

1. **Balloon Popping Problem (`017-풍선 터트리기.js`)**:
   * Implemented a solution to determine the maximum number of balloons that can remain after applying specific rules.
   * Utilized two passes (left-to-right and right-to-left) to track the minimum values and count valid balloons.

2. **Multilevel Toothbrush Sales Problem (`018-다단계 칫솔 판매.js`)**:
   * Implemented a solution to calculate the earnings of each member in a multilevel marketing structure.
   * Used a depth-first search (DFS) approach to propagate earnings up the hierarchy while deducting a percentage for the leader.